### PR TITLE
`jsxBracketSameLine` から `bracketSameLine` に移行 & prettier の要求バージョンを 2.4.0 以上に

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ module.exports = {
   trailingComma: 'all',
   // 可視性のためブランケットの脇には常にスペースを挿入する
   bracketSpacing: true,
-  // 可視性のため、JSXの `>` は改行せずにタグ名やプロパティと同じ行に挿入する
-  jsxBracketSameLine: true,
+  // 可視性のため、HTML/JSXの `>` は改行せずにタグ名やプロパティと同じ行に挿入する
+  bracketSameLine: true,
   // 引数を括弧を付けること無く増やせるように & 統一性を保つため、アロー関数の引数リストの括弧は必ず付ける
   arrowParens: 'always',
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "index.js"
   ],
   "peerDependencies": {
-    "prettier": ">=1.17.0"
+    "prettier": ">=2.4.0"
   },
   "peerDependenciesMeta": {
     "prettier": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     }
   },
   "devDependencies": {
-    "prettier": "^2.2.0"
+    "prettier": "^2.8.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-prettier@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.0.tgz#8a03c7777883b29b37fb2c4348c66a78e980418b"
-  integrity sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==
+prettier@^2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.3.tgz#ab697b1d3dd46fb4626fbe2f543afe0cc98d8632"
+  integrity sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==


### PR DESCRIPTION
close: #1 